### PR TITLE
feat(bagua-exchange): initialize exchange module structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,10 +60,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "bagua-engine"
@@ -58,8 +99,12 @@ version = "1.0.0"
 name = "bagua-exchange"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "bagua-helpers",
  "bagua-types",
+ "chrono",
+ "tokio",
 ]
 
 [[package]]
@@ -105,6 +150,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
@@ -208,6 +259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +355,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +383,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -379,10 +466,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "parse-zoneinfo"
@@ -430,6 +549,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "portable-atomic"
@@ -571,6 +696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,10 +750,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -648,6 +794,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +813,16 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "syn"
@@ -675,6 +840,35 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tokio"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -838,6 +1032,15 @@ name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]

--- a/bagua-exchange/Cargo.toml
+++ b/bagua-exchange/Cargo.toml
@@ -8,5 +8,9 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
-bagua-types = { workspace = true }
 bagua-helpers = { workspace = true }
+bagua-types = { workspace = true }
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+tokio = { workspace = true }

--- a/bagua-exchange/src/event.rs
+++ b/bagua-exchange/src/event.rs
@@ -1,0 +1,69 @@
+use bagua_types::prelude::*;
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone)]
+pub enum ExchangeEvent {
+    MarkPrice(PriceEvent),
+    IndexPrice(PriceEvent),
+    LastPrice(PriceEvent),
+    FundingRate(PriceEvent),
+    Orderbook(OrderbookEvent),
+    Candle(CandleEvent),
+    LeverageUpdate(LeverageUpdateEvent),
+    OrderUpdate(OrderUpdateEvent),
+    PositionUpdate(PositionUpdateEvent),
+}
+
+#[derive(Debug, Clone)]
+pub struct PriceEvent {
+    pub exchange: ExchangeType,
+    pub product: ProductType,
+    pub code: String,
+    pub event_time: DateTime<Utc>,
+    pub price: Price,
+}
+
+#[derive(Debug, Clone)]
+pub struct OrderbookEvent {
+    pub exchange: ExchangeType,
+    pub product: ProductType,
+    pub code: String,
+    pub event_time: DateTime<Utc>,
+    pub orderbook: Orderbook,
+}
+
+#[derive(Debug, Clone)]
+pub struct CandleEvent {
+    pub exchange: ExchangeType,
+    pub product: ProductType,
+    pub code: String,
+    pub event_time: DateTime<Utc>,
+    pub candle: Candle,
+}
+
+#[derive(Debug, Clone)]
+pub struct LeverageUpdateEvent {
+    pub exchange: ExchangeType,
+    pub product: ProductType,
+    pub code: String,
+    pub event_time: DateTime<Utc>,
+    pub leverage: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct OrderUpdateEvent {
+    pub exchange: ExchangeType,
+    pub product: ProductType,
+    pub code: String,
+    pub event_time: DateTime<Utc>,
+    pub order: Order,
+}
+
+#[derive(Debug, Clone)]
+pub struct PositionUpdateEvent {
+    pub exchange: ExchangeType,
+    pub product: ProductType,
+    pub code: String,
+    pub event_time: DateTime<Utc>,
+    pub position: Position,
+}

--- a/bagua-exchange/src/lib.rs
+++ b/bagua-exchange/src/lib.rs
@@ -1,1 +1,3 @@
-
+pub mod prelude;
+pub mod traits;
+pub mod event;

--- a/bagua-exchange/src/prelude.rs
+++ b/bagua-exchange/src/prelude.rs
@@ -1,0 +1,1 @@
+pub use crate::{event::*, traits::*};

--- a/bagua-exchange/src/traits.rs
+++ b/bagua-exchange/src/traits.rs
@@ -1,0 +1,40 @@
+use crate::event::ExchangeEvent;
+use anyhow::Result;
+use async_trait::async_trait;
+use bagua_types::prelude::*;
+use chrono::{DateTime, Utc};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+#[async_trait]
+pub trait Exchange: Clone + Send + Sync {
+    async fn get_candles(
+        &self,
+        product: ProductType,
+        code: String,
+        interval: CandleInterval,
+        start_time: Option<DateTime<Utc>>,
+        end_time: Option<DateTime<Utc>>,
+        limit: Option<i64>,
+    ) -> Result<Vec<Candle>>;
+
+    async fn get_positions(&self) -> Result<Vec<Position>>;
+
+    async fn get_leverage(&self, product: ProductType, code: String) -> Result<i32>;
+
+    async fn get_order(
+        &self,
+        product: ProductType,
+        code: String,
+        id: String,
+    ) -> Result<Option<Order>>;
+
+    async fn get_open_orders(&self, product: ProductType, code: String) -> Result<Vec<Order>>;
+
+    async fn place_order(&self, order: Order) -> Result<()>;
+
+    async fn cancel_order(&self, product: ProductType, code: String, id: String) -> Result<()>;
+
+    async fn set_leverage(&self, product: ProductType, code: String, leverage: i32) -> Result<()>;
+
+    async fn subscribe(&self) -> Result<UnboundedReceiver<ExchangeEvent>>;
+}

--- a/bagua-types/src/models.rs
+++ b/bagua-types/src/models.rs
@@ -83,6 +83,7 @@ pub struct Order {
     pub create_time: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone)]
 pub struct Position {
     pub exchange: ExchangeType,
     pub product: ProductType,
@@ -93,10 +94,11 @@ pub struct Position {
     pub leverage: i32,
 }
 
+#[derive(Debug, Clone)]
 pub struct Account {
     pub exchange: ExchangeType,
     pub product: ProductType,
-    pub positions: HashMap<String, Position>,
+    pub positions: Vec<Position>,
     pub orders: HashMap<String, Order>,
 }
 
@@ -110,12 +112,14 @@ pub struct BacktestConfig {
     pub trade_slippage_rate: f64,
 }
 
+#[derive(Debug, Clone)]
 pub struct TestnetConfig {
     pub api_key: String,
     pub api_secret: String,
     pub api_passphrase: String,
 }
 
+#[derive(Debug, Clone)]
 pub struct MainnetConfig {
     pub api_key: String,
     pub api_secret: String,


### PR DESCRIPTION
- Added initial module structure for bagua-exchange
- Created prelude, traits, and event modules
- Updated Cargo.toml with new dependencies for async and error handling
- Modified models in bagua-types to support more flexible data structures