### PR TITLE
chore: bump workspace version to 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "bagua-engine"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "bagua-exchange"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "bagua-helpers"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -128,14 +128,14 @@ dependencies = [
 
 [[package]]
 name = "bagua-python-sdk"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "bagua-types"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "ringbuffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 authors = ["<husky-wealths> <husky@wealths.app"]
 description = "八卦量化库"
 edition = "2021"


### PR DESCRIPTION
- Updated version in Cargo.lock and Cargo.toml
- Incremented version for all workspace packages